### PR TITLE
Call original method in monkeypatch instead of default `false`

### DIFF
--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -68,7 +68,7 @@ module Pod
         if options.key?(:indexDownload)
           true
         else
-          false
+          orig_should_flatten?
         end
       end
 


### PR DESCRIPTION
Unsure of other use cases affected by this change, don't know how to test them. For my usage it resolves the problem is getting no sources after downloading the archive from artifactory.

Fixes #3 
