### PR TITLE
Fix issue with `pod update` (#15)

### DIFF
--- a/lib/art_source.rb
+++ b/lib/art_source.rb
@@ -23,5 +23,9 @@ module Pod
         File.read("#{repo}/.artpodrc") if File.exist?("#{dir}/.artpodrc")
       end
     end
+
+    def git?
+      false
+    end
   end
 end


### PR DESCRIPTION
Potential fix for issue #15.

Add an implementation of the `git?` method that just returns false, indicating an `ArtSource` is not git-based.