### PR TITLE
Cocoapods v1.8.0 fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,95 @@
+PATH
+  remote: .
+  specs:
+    cocoapods-art (1.0.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (3.0.1)
+    activesupport (4.2.11.1)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    algoliasearch (1.27.0)
+      httpclient (~> 2.8, >= 2.8.3)
+      json (>= 1.5.1)
+    atomos (0.1.3)
+    claide (1.0.3)
+    cocoapods (1.8.0)
+      activesupport (>= 4.0.2, < 5)
+      claide (>= 1.0.2, < 2.0)
+      cocoapods-core (= 1.8.0)
+      cocoapods-deintegrate (>= 1.0.3, < 2.0)
+      cocoapods-downloader (>= 1.2.2, < 2.0)
+      cocoapods-plugins (>= 1.0.0, < 2.0)
+      cocoapods-search (>= 1.0.0, < 2.0)
+      cocoapods-stats (>= 1.0.0, < 2.0)
+      cocoapods-trunk (>= 1.4.0, < 2.0)
+      cocoapods-try (>= 1.1.0, < 2.0)
+      colored2 (~> 3.1)
+      escape (~> 0.0.4)
+      fourflusher (>= 2.3.0, < 3.0)
+      gh_inspector (~> 1.0)
+      molinillo (~> 0.6.6)
+      nap (~> 1.0)
+      ruby-macho (~> 1.4)
+      xcodeproj (>= 1.11.1, < 2.0)
+    cocoapods-core (1.8.0)
+      activesupport (>= 4.0.2, < 6)
+      algoliasearch (~> 1.0)
+      concurrent-ruby (~> 1.0)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+    cocoapods-deintegrate (1.0.4)
+    cocoapods-downloader (1.2.2)
+    cocoapods-plugins (1.0.0)
+      nap
+    cocoapods-search (1.0.0)
+    cocoapods-stats (1.1.0)
+    cocoapods-trunk (1.4.0)
+      nap (>= 0.8, < 2.0)
+      netrc (~> 0.11)
+    cocoapods-try (1.1.0)
+    colored2 (3.1.2)
+    concurrent-ruby (1.1.5)
+    escape (0.0.4)
+    fourflusher (2.3.1)
+    fuzzy_match (2.0.4)
+    gh_inspector (1.1.3)
+    httpclient (2.8.3)
+    i18n (0.9.5)
+      concurrent-ruby (~> 1.0)
+    json (2.2.0)
+    minitest (5.12.0)
+    molinillo (0.6.6)
+    nanaimo (0.2.6)
+    nap (1.1.0)
+    netrc (0.11.0)
+    rake (0.9.6)
+    ruby-macho (1.4.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    xcodeproj (1.12.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.2.6)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.0.2)
+  claide
+  cocoapods
+  cocoapods-art!
+  cocoapods-core
+  cocoapods-downloader
+  rake (~> 0)
+
+BUNDLED WITH
+   2.0.2

--- a/cocoapods_art.gemspec
+++ b/cocoapods_art.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 2.0.2'
   spec.add_development_dependency 'rake',    '~> 0'
 end

--- a/lib/cocoapods_art.rb
+++ b/lib/cocoapods_art.rb
@@ -2,5 +2,5 @@
 # The namespace of the CocoaPods Artifactory plugin.
 #
 module CocoaPodsArt
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -119,8 +119,8 @@ module Pod
           def source_from_path(path)
             @sources_by_path ||= Hash.new do |hash, key|
               art_repo = "#{UTIL.get_repos_art_dir()}/#{key.basename}"
-              hash[key] = if key.basename.to_s == Pod::MasterSource::MASTER_REPO_NAME
-                            MasterSource.new(key)
+              hash[key] = if key.basename.to_s == Pod::TrunkSource::TRUNK_REPO_NAME
+                            TrunkSource.new(key)
                           elsif File.exist?("#{art_repo}/.artpodrc")
                             create_source_from_name(key.basename)
                           else


### PR DESCRIPTION
- Fixed issue where wrong source was used. In Cocoapods v1.8.0
- Updated version to v1.0.4
- Updated gemspec to bundler v2.0.2
- Added Gemfile.lock