### PR TITLE
Add support for --ssl-no-revoke

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ If your .netrc file is not located in your home directory, you can specify its l
 export COCOAPODS_ART_NETRC_PATH=$HOME/myproject/.netrc
 ```
 
-You could set the following environment variable: COCOAPODS_ART_SSL_NO_REOVKE, this will add the flag --ssl-no-revoke to curl command.
+You could set the following environment variable: COCOAPODS_ART_SSL_NO_REVOKE, this will add the flag --ssl-no-revoke to curl command.
 If your are running on an environment where access to CRL isn't available you would still be able to access Artifactory via HTTPS using the cocoapods-art plugin on windows.
 ```
-set COCOAPODS_ART_SSL_NO_REOVKE=true
+set COCOAPODS_ART_SSL_NO_REVOKE=true
 ```
 
 ## Artifactory Configuration

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ If your .netrc file is not located in your home directory, you can specify its l
 export COCOAPODS_ART_NETRC_PATH=$HOME/myproject/.netrc
 ```
 
+You could set the following environment variable: COCOAPODS_ART_SSL_NO_REOVKE, this will add the flag --ssl-no-revoke to curl command.
+If your are running on an environment where access to CRL isn't available you would still be able to access Artifactory via HTTPS using the cocoapods-art plugin on windows.
+```
+set COCOAPODS_ART_SSL_NO_REOVKE=true
+```
+
 ## Artifactory Configuration
 See the [Artifactory User Guide](https://www.jfrog.com/confluence/display/RTF/CocoaPods+Repositories)
 

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -61,7 +61,7 @@ module Pod
         netrc_path = ENV["COCOAPODS_ART_NETRC_PATH"]
         parameters.concat(["--netrc-file", Pathname.new(netrc_path).expand_path]) if netrc_path
 
-        winssl_no_revoke = ENV["COCOAPODS_ART_SSL_NO_REOVKE"]
+        winssl_no_revoke = ENV["COCOAPODS_ART_SSL_NO_REVOKE"]
         parameters.concat(["--ssl-no-revoke"]) if defined? winssl_no_revoke && "true".casecmp(winssl_no_revoke)
 
         headers.each do |h|

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -61,6 +61,9 @@ module Pod
         netrc_path = ENV["COCOAPODS_ART_NETRC_PATH"]
         parameters.concat(["--netrc-file", Pathname.new(netrc_path).expand_path]) if netrc_path
 
+        winssl_no_revoke = ENV["COCOAPODS_ART_SSL_NO_REOVKE"]
+        parameters.concat(["--ssl-no-revoke"]) if defined? winssl_no_revoke && "true".casecmp(winssl_no_revoke)
+
         headers.each do |h|
           parameters << '-H'
           parameters << h


### PR DESCRIPTION
Issue #47 

Add a new ENV var called COCOAPODS_ART_SSL_NO_REOVKE to be able to pass the flag --ssl-no-revoke when using curl with WinSSL