### PR TITLE
Allow credentials to be read from env instead of .netrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ If your .netrc file is not located in your home directory, you can specify its l
 export COCOAPODS_ART_NETRC_PATH=$HOME/myproject/.netrc
 ```
 
+Alternatively, you can specify a username and password/API key directly from an environment variable rather than utilizing the .netrc file, by setting the value of `COCOAPODS_ART_CREDENTIALS` to your Artifactory username and the password separated by a colon:
+
+```
+export COCOAPODS_ART_CREDENTIALS="admin:password"
+````
+
+If the `COCOAPODS_ART_CREDENTIALS` variable is set, its value will supercede any credentials specified in your .netrc file, causing them to be ignored.
+
 ## Artifactory Configuration
 See the [Artifactory User Guide](https://www.jfrog.com/confluence/display/RTF/CocoaPods+Repositories)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Alternatively, you can specify a username and password/API key directly from an 
 export COCOAPODS_ART_CREDENTIALS="admin:password"
 ````
 
-If the `COCOAPODS_ART_CREDENTIALS` variable is set, its value will supercede any credentials specified in your .netrc file, causing them to be ignored.
+If the `COCOAPODS_ART_CREDENTIALS` variable is set, its value will supersede any credentials specified in your .netrc file, causing them to be ignored.
 
 ## Artifactory Configuration
 See the [Artifactory User Guide](https://www.jfrog.com/confluence/display/RTF/CocoaPods+Repositories)

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -61,6 +61,10 @@ module Pod
         netrc_path = ENV["COCOAPODS_ART_NETRC_PATH"]
         parameters.concat(["--netrc-file", Pathname.new(netrc_path).expand_path]) if netrc_path
 
+        username = ENV["COCOAPODS_ART_USERNAME"]
+        password = ENV["COCOAPODS_ART_PASSWORD"]
+        parameters.concat(["--user", "#{username}:#{password}") if username && password
+
         headers.each do |h|
           parameters << '-H'
           parameters << h

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -61,9 +61,8 @@ module Pod
         netrc_path = ENV["COCOAPODS_ART_NETRC_PATH"]
         parameters.concat(["--netrc-file", Pathname.new(netrc_path).expand_path]) if netrc_path
 
-        username = ENV["COCOAPODS_ART_USERNAME"]
-        password = ENV["COCOAPODS_ART_PASSWORD"]
-        parameters.concat(["--user", "#{username}:#{password}") if username && password
+        art_credentials = ENV["COCOAPODS_ART_CREDENTIALS"]
+        parameters.concat(["--user", "#{art_credentials}") if art_credentials
 
         headers.each do |h|
           parameters << '-H'

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -62,7 +62,7 @@ module Pod
         parameters.concat(["--netrc-file", Pathname.new(netrc_path).expand_path]) if netrc_path
 
         art_credentials = ENV["COCOAPODS_ART_CREDENTIALS"]
-        parameters.concat(["--user", art_credentials) if art_credentials
+        parameters.concat(["--user", art_credentials]) if art_credentials
 
         headers.each do |h|
           parameters << '-H'

--- a/lib/cocoapods_plugin.rb
+++ b/lib/cocoapods_plugin.rb
@@ -62,7 +62,7 @@ module Pod
         parameters.concat(["--netrc-file", Pathname.new(netrc_path).expand_path]) if netrc_path
 
         art_credentials = ENV["COCOAPODS_ART_CREDENTIALS"]
-        parameters.concat(["--user", "#{art_credentials}") if art_credentials
+        parameters.concat(["--user", art_credentials) if art_credentials
 
         headers.each do |h|
           parameters << '-H'


### PR DESCRIPTION
This PR implements an option to store the Artifactory username and password in an environment variable, rather than in a file on disk. The current implementation of cocoapods-art does not support reading credentials from environment variables, instead requiring credentials to be hard-coded into the `.netrc` file. 

With this change, if the `COCOAPODS_ART_CREDENTIALS` variable is set, its value will be passed via the `--user` flag, consistent with the way that the project will currently pass the value of `COCOAPODS_ART_NETRC_PATH` via `--netrc-file` if set. Per the [Curl manpage](https://curl.se/docs/manpage.html#-u), the `--user` flag "Overrides -n, --netrc and --netrc-optional", so this will take precedence over the existing credentials implementation if used, without requiring any additional logic to switch between the two approaches. 